### PR TITLE
update personal limits for jira cloud

### DIFF
--- a/src/person-limits/SettingsPage/index.js
+++ b/src/person-limits/SettingsPage/index.js
@@ -117,6 +117,7 @@ export default class PersonalWIPLimit extends PageModification {
     const personLimit = {
       id: Date.now(),
       person: {
+        accountId: fullPerson.accountId,
         name: fullPerson.name ?? fullPerson.displayName,
         displayName: fullPerson.displayName,
         self: fullPerson.self,

--- a/src/shared/PageModification.js
+++ b/src/shared/PageModification.js
@@ -8,6 +8,7 @@ import {
   getBoardConfiguration,
   updateBoardProperty,
   searchIssues,
+  getLatestForBoard,
 } from './jiraApi';
 
 export class PageModification {
@@ -87,6 +88,22 @@ export class PageModification {
     this.sideEffects.push(cancelRequest);
 
     return getBoardEditData(getBoardIdFromURL(), { abortPromise });
+  }
+
+  getBoardLatest() {
+    const { cancelRequest, abortPromise } = this.createAbortPromise();
+    this.sideEffects.push(cancelRequest);
+
+    return getLatestForBoard(getBoardIdFromURL(), {
+      abortPromise,
+      query: {
+        hideCardExtraFields: true,
+        includeHidden: false,
+        moduleKey: 'agile-mobile-board-service',
+        skipEtag: false,
+        skipExtraFields: true,
+      },
+    });
   }
 
   getBoardEstimationData() {

--- a/src/shared/jiraApi.js
+++ b/src/shared/jiraApi.js
@@ -21,6 +21,7 @@ const boardPropertiesUrl = boardId => `agile/1.0/board/${boardId}/properties`;
 const boardConfigurationURL = boardId => `agile/1.0/board/${boardId}/configuration`;
 const boardEditDataURL = 'greenhopper/1.0/rapidviewconfig/editmodel.json?rapidViewId=';
 const boardEstimationDataURL = 'greenhopper/1.0/rapidviewconfig/estimation.json?rapidViewId=';
+const boardLatestURL = boardId => `boards/latest/board/${boardId}`;
 
 const invalidatedProperties = {};
 
@@ -136,6 +137,17 @@ export const searchIssues = (jql, params = {}) =>
     type: 'json',
     ...params,
   });
+
+export const getLatestForBoard = (boardId, params = {}) => {
+  return requestJira({
+    url: boardLatestURL(boardId),
+    type: 'json',
+    memoryCache: true,
+    memoryCacheTtl: 1000,
+    memoryCacheForce: true,
+    ...params,
+  });
+};
 
 export const loadNewIssueViewEnabled = (params = {}) =>
   requestJira({


### PR DESCRIPTION
Does things a bit differently:
- no longer poll DOM for issue data because of virtual scroll on board in jira cloud
- update limit stats without refreshing the board 
- keep accountId when creating limits so we can reuse it when calculating data (no more clashes because of similar names)

Tried to keep it backwards compatibly but have no way to test