### PR TITLE
update group limits on board page for jira cloud

### DIFF
--- a/src/column-limits/BoardPage/htmlTemplates.js
+++ b/src/column-limits/BoardPage/htmlTemplates.js
@@ -1,0 +1,6 @@
+import styles from './styles.css';
+export const boardPageColumnHeaderBadge = ({ amountOfGroupTasks, groupLimit, isCloud = false }) => `
+    <span class="${isCloud ? styles.limitColumnBadgeCloud : styles.limitColumnBadge}">
+      ${amountOfGroupTasks}/${groupLimit}
+      <span class="${isCloud ? styles.limitColumnBadgeCloud__hint : styles.limitColumnBadge__hint}">Issues per group / Max number of issues per group</span>
+    </span>`;

--- a/src/column-limits/BoardPage/index.js
+++ b/src/column-limits/BoardPage/index.js
@@ -166,21 +166,19 @@ export default class ColumnLimitsBoardPage extends PageModification {
             0
         );
 
-        if (amountOfGroupTasks > groupLimit) {
-          groupColumns.forEach(groupColumnId => {
-            const index = boardLatest?.columns?.findIndex(column => {
-              return String(column.id) === String(groupColumnId);
-            });
-            if (index > -1) {
-              const insertedElement = this.insertHTML(columnElements[index], 'beforeend', boardPageColumnHeaderBadge({
-                isCloud: true,
-                amountOfGroupTasks,
-                groupLimit,
-              }));
-              this.insertedBadges.push(insertedElement);
-            }
+        groupColumns.forEach(groupColumnId => {
+          const index = boardLatest?.columns?.findIndex(column => {
+            return String(column.id) === String(groupColumnId);
           });
-        }
+          if (index > -1) {
+            const insertedElement = this.insertHTML(columnElements[index], 'beforeend', boardPageColumnHeaderBadge({
+              isCloud: true,
+              amountOfGroupTasks,
+              groupLimit,
+            }));
+            this.insertedBadges.push(insertedElement);
+          }
+        });
       });
     }
 

--- a/src/column-limits/BoardPage/styles.css
+++ b/src/column-limits/BoardPage/styles.css
@@ -31,3 +31,38 @@
   z-index: 100000;
   transition-delay: 200ms;
 }
+
+/* Jira Cloud */
+.limitColumnBadgeCloud {
+  position: absolute;
+  top: -24%;
+  left: 4%;
+  padding: 4px;
+  border-radius: 5px;
+  font-size: 0.8rem;
+  margin: 0 10px;
+  color: white;
+  background-color: #1b855c;
+}
+
+.limitColumnBadgeCloud__hint {
+  visibility: hidden;
+  position: absolute;
+  padding: 2px 3px;
+  margin-left: 8px;
+  width: 130px;
+  transition: 0s visibility;
+  cursor: pointer;
+}
+
+.limitColumnBadgeCloud:hover .limitColumnBadgeCloud__hint {
+  visibility: visible;
+  display: inline;
+  color: black;
+  padding: 10px;
+  background-color: white;
+  border-radius: 5px;
+  box-shadow: 0 0 5px rgba(0,0,0,0.5); /* Параметры тени */
+  z-index: 100000;
+  transition-delay: 200ms;
+}

--- a/src/person-limits/SettingsPage/index.js
+++ b/src/person-limits/SettingsPage/index.js
@@ -117,6 +117,7 @@ export default class PersonalWIPLimit extends PageModification {
     const personLimit = {
       id: Date.now(),
       person: {
+        accountId: fullPerson.accountId,
         name: fullPerson.name ?? fullPerson.displayName,
         displayName: fullPerson.displayName,
         self: fullPerson.self,

--- a/src/shared/PageModification.js
+++ b/src/shared/PageModification.js
@@ -8,6 +8,7 @@ import {
   getBoardConfiguration,
   updateBoardProperty,
   searchIssues,
+  getLatestForBoard,
 } from './jiraApi';
 
 export class PageModification {
@@ -87,6 +88,22 @@ export class PageModification {
     this.sideEffects.push(cancelRequest);
 
     return getBoardEditData(getBoardIdFromURL(), { abortPromise });
+  }
+
+  getBoardLatest() {
+    const { cancelRequest, abortPromise } = this.createAbortPromise();
+    this.sideEffects.push(cancelRequest);
+
+    return getLatestForBoard(getBoardIdFromURL(), {
+      abortPromise,
+      query: {
+        hideCardExtraFields: true,
+        includeHidden: false,
+        moduleKey: 'agile-mobile-board-service',
+        skipEtag: false,
+        skipExtraFields: true,
+      },
+    });
   }
 
   getBoardEstimationData() {

--- a/src/shared/PageModification.js
+++ b/src/shared/PageModification.js
@@ -140,7 +140,7 @@ export class PageModification {
     this.sideEffects.push(() => target.removeEventListener(event, cb));
   };
 
-  onDOMChange(selector, cb, params = { childList: true }) {
+  onDOMChange(selector, cb, params = { childList: true, subtree: false, }) {
     const element = document.querySelector(selector);
     if (!element) return;
 

--- a/src/shared/jiraApi.js
+++ b/src/shared/jiraApi.js
@@ -21,6 +21,7 @@ const boardPropertiesUrl = boardId => `agile/1.0/board/${boardId}/properties`;
 const boardConfigurationURL = boardId => `agile/1.0/board/${boardId}/configuration`;
 const boardEditDataURL = 'greenhopper/1.0/rapidviewconfig/editmodel.json?rapidViewId=';
 const boardEstimationDataURL = 'greenhopper/1.0/rapidviewconfig/estimation.json?rapidViewId=';
+const boardLatestURL = boardId => `boards/latest/board/${boardId}`;
 
 const invalidatedProperties = {};
 
@@ -136,6 +137,17 @@ export const searchIssues = (jql, params = {}) =>
     type: 'json',
     ...params,
   });
+
+export const getLatestForBoard = (boardId, params = {}) => {
+  return requestJira({
+    url: boardLatestURL(boardId),
+    type: 'json',
+    memoryCache: true,
+    memoryCacheTtl: 1000,
+    memoryCacheForce: true,
+    ...params,
+  });
+};
 
 export const loadNewIssueViewEnabled = (params = {}) =>
   requestJira({

--- a/src/swimlane/utils.js
+++ b/src/swimlane/utils.js
@@ -1,6 +1,10 @@
 export const mergeSwimlaneSettings = ([settings, oldLimits]) => {
   if (settings) return settings;
 
+  if (typeof settings === 'undefined' && typeof oldLimits === 'undefined') {
+    return {};
+  }
+
   const convertedSettings = {};
 
   if (oldLimits) {


### PR DESCRIPTION
As previous PR this one pulls latest board data info instead of trying to get it from the dom, same reasons

Needs to be tested on different jira versions